### PR TITLE
feat: free shipping for orders >= $50 USD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -1,0 +1,420 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"cloud.google.com/go/profiler"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/GoogleCloudPlatform/microservices-demo/src/checkoutservice/genproto"
+	money "github.com/GoogleCloudPlatform/microservices-demo/src/checkoutservice/money"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+const (
+	listenPort  = "5050"
+	usdCurrency = "USD"
+)
+
+var log *logrus.Logger
+
+func init() {
+	log = logrus.New()
+	log.Level = logrus.DebugLevel
+	log.Formatter = &logrus.JSONFormatter{
+		FieldMap: logrus.FieldMap{
+			logrus.FieldKeyTime:  "timestamp",
+			logrus.FieldKeyLevel: "severity",
+			logrus.FieldKeyMsg:   "message",
+		},
+		TimestampFormat: time.RFC3339Nano,
+	}
+	log.Out = os.Stdout
+}
+
+type checkoutService struct {
+	productCatalogSvcAddr string
+	productCatalogSvcConn *grpc.ClientConn
+
+	cartSvcAddr string
+	cartSvcConn *grpc.ClientConn
+
+	currencySvcAddr string
+	currencySvcConn *grpc.ClientConn
+
+	shippingSvcAddr string
+	shippingSvcConn *grpc.ClientConn
+
+	emailSvcAddr string
+	emailSvcConn *grpc.ClientConn
+
+	paymentSvcAddr string
+	paymentSvcConn *grpc.ClientConn
+}
+
+func main() {
+	ctx := context.Background()
+	if os.Getenv("ENABLE_TRACING") == "1" {
+		log.Info("Tracing enabled.")
+		initTracing()
+
+	} else {
+		log.Info("Tracing disabled.")
+	}
+
+	if os.Getenv("ENABLE_PROFILER") == "1" {
+		log.Info("Profiling enabled.")
+		go initProfiling("checkoutservice", "1.0.0")
+	} else {
+		log.Info("Profiling disabled.")
+	}
+
+	port := listenPort
+	if os.Getenv("PORT") != "" {
+		port = os.Getenv("PORT")
+	}
+
+	svc := new(checkoutService)
+	mustMapEnv(&svc.shippingSvcAddr, "SHIPPING_SERVICE_ADDR")
+	mustMapEnv(&svc.productCatalogSvcAddr, "PRODUCT_CATALOG_SERVICE_ADDR")
+	mustMapEnv(&svc.cartSvcAddr, "CART_SERVICE_ADDR")
+	mustMapEnv(&svc.currencySvcAddr, "CURRENCY_SERVICE_ADDR")
+	mustMapEnv(&svc.emailSvcAddr, "EMAIL_SERVICE_ADDR")
+	mustMapEnv(&svc.paymentSvcAddr, "PAYMENT_SERVICE_ADDR")
+
+	mustConnGRPC(ctx, &svc.shippingSvcConn, svc.shippingSvcAddr)
+	mustConnGRPC(ctx, &svc.productCatalogSvcConn, svc.productCatalogSvcAddr)
+	mustConnGRPC(ctx, &svc.cartSvcConn, svc.cartSvcAddr)
+	mustConnGRPC(ctx, &svc.currencySvcConn, svc.currencySvcAddr)
+	mustConnGRPC(ctx, &svc.emailSvcConn, svc.emailSvcAddr)
+	mustConnGRPC(ctx, &svc.paymentSvcConn, svc.paymentSvcAddr)
+
+	log.Infof("service config: %+v", svc)
+
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var srv *grpc.Server
+
+	// Propagate trace context always
+	otel.SetTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{}, propagation.Baggage{}))
+	srv = grpc.NewServer(
+		grpc.UnaryInterceptor(otelgrpc.UnaryServerInterceptor()),
+		grpc.StreamInterceptor(otelgrpc.StreamServerInterceptor()),
+	)
+
+	pb.RegisterCheckoutServiceServer(srv, svc)
+	healthpb.RegisterHealthServer(srv, svc)
+	log.Infof("starting to listen on tcp: %q", lis.Addr().String())
+	err = srv.Serve(lis)
+	log.Fatal(err)
+}
+
+func initStats() {
+	//TODO(arbrown) Implement OpenTelemetry stats
+}
+
+func initTracing() {
+	var (
+		collectorAddr string
+		collectorConn *grpc.ClientConn
+	)
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+
+	mustMapEnv(&collectorAddr, "COLLECTOR_SERVICE_ADDR")
+	mustConnGRPC(ctx, &collectorConn, collectorAddr)
+
+	exporter, err := otlptracegrpc.New(
+		ctx,
+		otlptracegrpc.WithGRPCConn(collectorConn))
+	if err != nil {
+		log.Warnf("warn: Failed to create trace exporter: %v", err)
+	}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	otel.SetTracerProvider(tp)
+
+}
+
+func initProfiling(service, version string) {
+	// TODO(ahmetb) this method is duplicated in other microservices using Go
+	// since they are not sharing packages.
+	for i := 1; i <= 3; i++ {
+		if err := profiler.Start(profiler.Config{
+			Service:        service,
+			ServiceVersion: version,
+			// ProjectID must be set if not running on GCP.
+			// ProjectID: "my-project",
+		}); err != nil {
+			log.Warnf("failed to start profiler: %+v", err)
+		} else {
+			log.Info("started Stackdriver profiler")
+			return
+		}
+		d := time.Second * 10 * time.Duration(i)
+		log.Infof("sleeping %v to retry initializing Stackdriver profiler", d)
+		time.Sleep(d)
+	}
+	log.Warn("could not initialize Stackdriver profiler after retrying, giving up")
+}
+
+func mustMapEnv(target *string, envKey string) {
+	v := os.Getenv(envKey)
+	if v == "" {
+		panic(fmt.Sprintf("environment variable %q not set", envKey))
+	}
+	*target = v
+}
+
+func mustConnGRPC(ctx context.Context, conn **grpc.ClientConn, addr string) {
+	var err error
+	ctx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+	*conn, err = grpc.DialContext(ctx, addr,
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
+		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()))
+	if err != nil {
+		panic(errors.Wrapf(err, "grpc: failed to connect %s", addr))
+	}
+}
+
+func (cs *checkoutService) Check(ctx context.Context, req *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVING}, nil
+}
+
+func (cs *checkoutService) Watch(req *healthpb.HealthCheckRequest, ws healthpb.Health_WatchServer) error {
+	return status.Errorf(codes.Unimplemented, "health check via Watch not implemented")
+}
+
+func (cs *checkoutService) PlaceOrder(ctx context.Context, req *pb.PlaceOrderRequest) (*pb.PlaceOrderResponse, error) {
+	log.Infof("[PlaceOrder] user_id=%q user_currency=%q", req.UserId, req.UserCurrency)
+
+	orderID, err := uuid.NewUUID()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to generate order uuid")
+	}
+
+	prep, err := cs.prepareOrderItemsAndShippingQuoteFromCart(ctx, req.UserId, req.UserCurrency, req.Address)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, err.Error())
+	}
+
+	total := pb.Money{CurrencyCode: req.UserCurrency,
+		Units: 0,
+		Nanos: 0}
+	total = money.Must(money.Sum(total, *prep.shippingCostLocalized))
+	for _, it := range prep.orderItems {
+		multPrice := money.MultiplySlow(*it.Cost, uint32(it.GetItem().GetQuantity()))
+		total = money.Must(money.Sum(total, multPrice))
+	}
+
+	txID, err := cs.chargeCard(ctx, &total, req.CreditCard)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to charge card: %+v", err)
+	}
+	log.Infof("payment went through (transaction_id: %s)", txID)
+
+	shippingTrackingID, err := cs.shipOrder(ctx, req.Address, prep.cartItems)
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "shipping error: %+v", err)
+	}
+
+	_ = cs.emptyUserCart(ctx, req.UserId)
+
+	orderResult := &pb.OrderResult{
+		OrderId:            orderID.String(),
+		ShippingTrackingId: shippingTrackingID,
+		ShippingCost:       prep.shippingCostLocalized,
+		ShippingAddress:    req.Address,
+		Items:              prep.orderItems,
+	}
+
+	if err := cs.sendOrderConfirmation(ctx, req.Email, orderResult); err != nil {
+		log.Warnf("failed to send order confirmation to %q: %+v", req.Email, err)
+	} else {
+		log.Infof("order confirmation email sent to %q", req.Email)
+	}
+	resp := &pb.PlaceOrderResponse{Order: orderResult}
+	return resp, nil
+}
+
+type orderPrep struct {
+	orderItems            []*pb.OrderItem
+	cartItems             []*pb.CartItem
+	shippingCostLocalized *pb.Money
+}
+
+const (
+	freeShippingThresholdUSD = int64(50) // orders with item subtotal >= $50 USD get free shipping
+)
+
+func (cs *checkoutService) prepareOrderItemsAndShippingQuoteFromCart(ctx context.Context, userID, userCurrency string, address *pb.Address) (orderPrep, error) {
+	var out orderPrep
+	cartItems, err := cs.getUserCart(ctx, userID)
+	if err != nil {
+		return out, fmt.Errorf("cart failure: %+v", err)
+	}
+	orderItems, err := cs.prepOrderItems(ctx, cartItems, userCurrency)
+	if err != nil {
+		return out, fmt.Errorf("failed to prepare order: %+v", err)
+	}
+	shippingUSD, err := cs.quoteShipping(ctx, address, cartItems)
+	if err != nil {
+		return out, fmt.Errorf("shipping quote failure: %+v", err)
+	}
+
+	// Apply free shipping when the item subtotal in USD meets the threshold.
+	subtotalUSD, err := cs.itemSubtotalUSD(ctx, cartItems)
+	if err != nil {
+		return out, fmt.Errorf("failed to compute item subtotal: %+v", err)
+	}
+	if subtotalUSD.GetUnits() >= freeShippingThresholdUSD {
+		shippingUSD = &pb.Money{CurrencyCode: usdCurrency, Units: 0, Nanos: 0}
+	}
+
+	shippingPrice, err := cs.convertCurrency(ctx, shippingUSD, userCurrency)
+	if err != nil {
+		return out, fmt.Errorf("failed to convert shipping cost to currency: %+v", err)
+	}
+
+	out.shippingCostLocalized = shippingPrice
+	out.cartItems = cartItems
+	out.orderItems = orderItems
+	return out, nil
+}
+
+// itemSubtotalUSD sums the USD prices of all items in the cart.
+func (cs *checkoutService) itemSubtotalUSD(ctx context.Context, items []*pb.CartItem) (*pb.Money, error) {
+	cl := pb.NewProductCatalogServiceClient(cs.productCatalogSvcConn)
+	subtotal := pb.Money{CurrencyCode: usdCurrency, Units: 0, Nanos: 0}
+	for _, item := range items {
+		product, err := cl.GetProduct(ctx, &pb.GetProductRequest{Id: item.GetProductId()})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get product #%q for subtotal: %+v", item.GetProductId(), err)
+		}
+		itemTotal := money.MultiplySlow(*product.GetPriceUsd(), uint32(item.GetQuantity()))
+		subtotal = money.Must(money.Sum(subtotal, itemTotal))
+	}
+	return &subtotal, nil
+}
+
+func (cs *checkoutService) quoteShipping(ctx context.Context, address *pb.Address, items []*pb.CartItem) (*pb.Money, error) {
+	shippingQuote, err := pb.NewShippingServiceClient(cs.shippingSvcConn).
+		GetQuote(ctx, &pb.GetQuoteRequest{
+			Address: address,
+			Items:   items})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get shipping quote: %+v", err)
+	}
+	return shippingQuote.GetCostUsd(), nil
+}
+
+func (cs *checkoutService) getUserCart(ctx context.Context, userID string) ([]*pb.CartItem, error) {
+	cart, err := pb.NewCartServiceClient(cs.cartSvcConn).GetCart(ctx, &pb.GetCartRequest{UserId: userID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user cart during checkout: %+v", err)
+	}
+	return cart.GetItems(), nil
+}
+
+func (cs *checkoutService) emptyUserCart(ctx context.Context, userID string) error {
+	if _, err := pb.NewCartServiceClient(cs.cartSvcConn).EmptyCart(ctx, &pb.EmptyCartRequest{UserId: userID}); err != nil {
+		return fmt.Errorf("failed to empty user cart during checkout: %+v", err)
+	}
+	return nil
+}
+
+func (cs *checkoutService) prepOrderItems(ctx context.Context, items []*pb.CartItem, userCurrency string) ([]*pb.OrderItem, error) {
+	out := make([]*pb.OrderItem, len(items))
+	cl := pb.NewProductCatalogServiceClient(cs.productCatalogSvcConn)
+
+	for i, item := range items {
+		product, err := cl.GetProduct(ctx, &pb.GetProductRequest{Id: item.GetProductId()})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get product #%q", item.GetProductId())
+		}
+		price, err := cs.convertCurrency(ctx, product.GetPriceUsd(), userCurrency)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert price of %q to %s", item.GetProductId(), userCurrency)
+		}
+		out[i] = &pb.OrderItem{
+			Item: item,
+			Cost: price}
+	}
+	return out, nil
+}
+
+func (cs *checkoutService) convertCurrency(ctx context.Context, from *pb.Money, toCurrency string) (*pb.Money, error) {
+	result, err := pb.NewCurrencyServiceClient(cs.currencySvcConn).Convert(context.TODO(), &pb.CurrencyConversionRequest{
+		From:   from,
+		ToCode: toCurrency})
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert currency: %+v", err)
+	}
+	return result, err
+}
+
+func (cs *checkoutService) chargeCard(ctx context.Context, amount *pb.Money, paymentInfo *pb.CreditCardInfo) (string, error) {
+	paymentResp, err := pb.NewPaymentServiceClient(cs.paymentSvcConn).Charge(ctx, &pb.ChargeRequest{
+		Amount:     amount,
+		CreditCard: paymentInfo})
+	if err != nil {
+		return "", fmt.Errorf("could not charge the card: %+v", err)
+	}
+	return paymentResp.GetTransactionId(), nil
+}
+
+func (cs *checkoutService) sendOrderConfirmation(ctx context.Context, email string, order *pb.OrderResult) error {
+	_, err := pb.NewEmailServiceClient(cs.emailSvcConn).SendOrderConfirmation(ctx, &pb.SendOrderConfirmationRequest{
+		Email: email,
+		Order: order})
+	return err
+}
+
+func (cs *checkoutService) shipOrder(ctx context.Context, address *pb.Address, items []*pb.CartItem) (string, error) {
+	resp, err := pb.NewShippingServiceClient(cs.shippingSvcConn).ShipOrder(ctx, &pb.ShipOrderRequest{
+		Address: address,
+		Items:   items})
+	if err != nil {
+		return "", fmt.Errorf("shipment failed: %+v", err)
+	}
+	return resp.GetTrackingId(), nil
+}

--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -1,0 +1,535 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	pb "github.com/GoogleCloudPlatform/microservices-demo/src/frontend/genproto"
+	"github.com/GoogleCloudPlatform/microservices-demo/src/frontend/money"
+)
+
+type platformDetails struct {
+	css      string
+	provider string
+}
+
+var (
+	isCymbalBrand = "true" == strings.ToLower(os.Getenv("CYMBAL_BRANDING"))
+	templates     = template.Must(template.New("").
+			Funcs(template.FuncMap{
+			"renderMoney":        renderMoney,
+			"renderCurrencyLogo": renderCurrencyLogo,
+		}).ParseGlob("templates/*.html"))
+	plat platformDetails
+)
+
+var validEnvs = []string{"local", "gcp", "azure", "aws", "onprem", "alibaba"}
+
+func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
+	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
+	log.WithField("currency", currentCurrency(r)).Info("home")
+	currencies, err := fe.getCurrencies(r.Context())
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve currencies"), http.StatusInternalServerError)
+		return
+	}
+	products, err := fe.getProducts(r.Context())
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve products"), http.StatusInternalServerError)
+		return
+	}
+	cart, err := fe.getCart(r.Context(), sessionID(r))
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve cart"), http.StatusInternalServerError)
+		return
+	}
+
+	type productView struct {
+		Item  *pb.Product
+		Price *pb.Money
+	}
+	ps := make([]productView, len(products))
+	for i, p := range products {
+		price, err := fe.convertCurrency(r.Context(), p.GetPriceUsd(), currentCurrency(r))
+		if err != nil {
+			renderHTTPError(log, r, w, errors.Wrapf(err, "failed to do currency conversion for product %s", p.GetId()), http.StatusInternalServerError)
+			return
+		}
+		ps[i] = productView{p, price}
+	}
+
+	// Set ENV_PLATFORM (default to local if not set; use env var if set; otherwise detect GCP, which overrides env)_
+	var env = os.Getenv("ENV_PLATFORM")
+	// Only override from env variable if set + valid env
+	if env == "" || stringinSlice(validEnvs, env) == false {
+		fmt.Println("env platform is either empty or invalid")
+		env = "local"
+	}
+	// Autodetect GCP
+	addrs, err := net.LookupHost("metadata.google.internal.")
+	if err == nil && len(addrs) >= 0 {
+		log.Debugf("Detected Google metadata server: %v, setting ENV_PLATFORM to GCP.", addrs)
+		env = "gcp"
+	}
+
+	log.Debugf("ENV_PLATFORM is: %s", env)
+	plat = platformDetails{}
+	plat.setPlatformDetails(strings.ToLower(env))
+
+	if err := templates.ExecuteTemplate(w, "home", map[string]interface{}{
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"user_currency":     currentCurrency(r),
+		"show_currency":     true,
+		"currencies":        currencies,
+		"products":          ps,
+		"cart_size":         cartSize(cart),
+		"banner_color":      os.Getenv("BANNER_COLOR"), // illustrates canary deployments
+		"ad":                fe.chooseAd(r.Context(), []string{}, log),
+		"platform_css":      plat.css,
+		"platform_name":     plat.provider,
+		"is_cymbal_brand":   isCymbalBrand,
+		"deploymentDetails": deploymentDetailsMap,
+	}); err != nil {
+		log.Error(err)
+	}
+}
+
+func (plat *platformDetails) setPlatformDetails(env string) {
+	if env == "aws" {
+		plat.provider = "AWS"
+		plat.css = "aws-platform"
+	} else if env == "onprem" {
+		plat.provider = "On-Premises"
+		plat.css = "onprem-platform"
+	} else if env == "azure" {
+		plat.provider = "Azure"
+		plat.css = "azure-platform"
+	} else if env == "gcp" {
+		plat.provider = "Google Cloud"
+		plat.css = "gcp-platform"
+	} else if env == "alibaba" {
+		plat.provider = "Alibaba Cloud"
+		plat.css = "alibaba-platform"
+	} else {
+		plat.provider = "local"
+		plat.css = "local"
+	}
+}
+
+func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request) {
+	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
+	id := mux.Vars(r)["id"]
+	if id == "" {
+		renderHTTPError(log, r, w, errors.New("product id not specified"), http.StatusBadRequest)
+		return
+	}
+	log.WithField("id", id).WithField("currency", currentCurrency(r)).
+		Debug("serving product page")
+
+	p, err := fe.getProduct(r.Context(), id)
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve product"), http.StatusInternalServerError)
+		return
+	}
+	currencies, err := fe.getCurrencies(r.Context())
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve currencies"), http.StatusInternalServerError)
+		return
+	}
+
+	cart, err := fe.getCart(r.Context(), sessionID(r))
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve cart"), http.StatusInternalServerError)
+		return
+	}
+
+	price, err := fe.convertCurrency(r.Context(), p.GetPriceUsd(), currentCurrency(r))
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "failed to convert currency"), http.StatusInternalServerError)
+		return
+	}
+
+	// ignores the error retrieving recommendations since it is not critical
+	recommendations, err := fe.getRecommendations(r.Context(), sessionID(r), []string{id})
+	if err != nil {
+		log.WithField("error", err).Warn("failed to get product recommendations")
+	}
+
+	product := struct {
+		Item  *pb.Product
+		Price *pb.Money
+	}{p, price}
+
+	if err := templates.ExecuteTemplate(w, "product", map[string]interface{}{
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"ad":                fe.chooseAd(r.Context(), p.Categories, log),
+		"user_currency":     currentCurrency(r),
+		"show_currency":     true,
+		"currencies":        currencies,
+		"product":           product,
+		"recommendations":   recommendations,
+		"cart_size":         cartSize(cart),
+		"platform_css":      plat.css,
+		"platform_name":     plat.provider,
+		"is_cymbal_brand":   isCymbalBrand,
+		"deploymentDetails": deploymentDetailsMap,
+	}); err != nil {
+		log.Println(err)
+	}
+}
+
+func (fe *frontendServer) addToCartHandler(w http.ResponseWriter, r *http.Request) {
+	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
+	quantity, _ := strconv.ParseUint(r.FormValue("quantity"), 10, 32)
+	productID := r.FormValue("product_id")
+	if productID == "" || quantity == 0 {
+		renderHTTPError(log, r, w, errors.New("invalid form input"), http.StatusBadRequest)
+		return
+	}
+	log.WithField("product", productID).WithField("quantity", quantity).Debug("adding to cart")
+
+	p, err := fe.getProduct(r.Context(), productID)
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve product"), http.StatusInternalServerError)
+		return
+	}
+
+	if err := fe.insertCart(r.Context(), sessionID(r), p.GetId(), int32(quantity)); err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "failed to add to cart"), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("location", "/cart")
+	w.WriteHeader(http.StatusFound)
+}
+
+func (fe *frontendServer) emptyCartHandler(w http.ResponseWriter, r *http.Request) {
+	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
+	log.Debug("emptying cart")
+
+	if err := fe.emptyCart(r.Context(), sessionID(r)); err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "failed to empty cart"), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("location", "/")
+	w.WriteHeader(http.StatusFound)
+}
+
+const (
+	freeShippingThresholdUSD = int64(50) // cart subtotal >= $50 USD qualifies for free shipping
+)
+
+func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request) {
+	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
+	log.Debug("view user cart")
+	currencies, err := fe.getCurrencies(r.Context())
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve currencies"), http.StatusInternalServerError)
+		return
+	}
+	cart, err := fe.getCart(r.Context(), sessionID(r))
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve cart"), http.StatusInternalServerError)
+		return
+	}
+
+	// ignores the error retrieving recommendations since it is not critical
+	recommendations, err := fe.getRecommendations(r.Context(), sessionID(r), cartIDs(cart))
+	if err != nil {
+		log.WithField("error", err).Warn("failed to get product recommendations")
+	}
+
+	shippingCost, err := fe.getShippingQuote(r.Context(), cart, currentCurrency(r))
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "failed to get shipping quote"), http.StatusInternalServerError)
+		return
+	}
+
+	type cartItemView struct {
+		Item     *pb.Product
+		Quantity int32
+		Price    *pb.Money
+	}
+	items := make([]cartItemView, len(cart))
+	totalPrice := pb.Money{CurrencyCode: currentCurrency(r)}
+	subtotalUSD := pb.Money{CurrencyCode: "USD"}
+	for i, item := range cart {
+		p, err := fe.getProduct(r.Context(), item.GetProductId())
+		if err != nil {
+			renderHTTPError(log, r, w, errors.Wrapf(err, "could not retrieve product #%s", item.GetProductId()), http.StatusInternalServerError)
+			return
+		}
+		price, err := fe.convertCurrency(r.Context(), p.GetPriceUsd(), currentCurrency(r))
+		if err != nil {
+			renderHTTPError(log, r, w, errors.Wrapf(err, "could not convert currency for product #%s", item.GetProductId()), http.StatusInternalServerError)
+			return
+		}
+
+		multPrice := money.MultiplySlow(*price, uint32(item.GetQuantity()))
+		items[i] = cartItemView{
+			Item:     p,
+			Quantity: item.GetQuantity(),
+			Price:    &multPrice}
+		totalPrice = money.Must(money.Sum(totalPrice, multPrice))
+
+		// Accumulate USD subtotal to evaluate free shipping threshold.
+		usdItemTotal := money.MultiplySlow(*p.GetPriceUsd(), uint32(item.GetQuantity()))
+		subtotalUSD = money.Must(money.Sum(subtotalUSD, usdItemTotal))
+	}
+
+	// Override shipping to free when the USD item subtotal meets the threshold.
+	if subtotalUSD.GetUnits() >= freeShippingThresholdUSD {
+		shippingCost = &pb.Money{CurrencyCode: currentCurrency(r), Units: 0, Nanos: 0}
+	}
+
+	totalPrice = money.Must(money.Sum(totalPrice, *shippingCost))
+	year := time.Now().Year()
+
+	if err := templates.ExecuteTemplate(w, "cart", map[string]interface{}{
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"user_currency":     currentCurrency(r),
+		"currencies":        currencies,
+		"recommendations":   recommendations,
+		"cart_size":         cartSize(cart),
+		"shipping_cost":     shippingCost,
+		"show_currency":     true,
+		"total_cost":        totalPrice,
+		"items":             items,
+		"expiration_years":  []int{year, year + 1, year + 2, year + 3, year + 4},
+		"platform_css":      plat.css,
+		"platform_name":     plat.provider,
+		"is_cymbal_brand":   isCymbalBrand,
+		"deploymentDetails": deploymentDetailsMap,
+	}); err != nil {
+		log.Println(err)
+	}
+}
+
+func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Request) {
+	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
+	log.Debug("placing order")
+
+	var (
+		email         = r.FormValue("email")
+		streetAddress = r.FormValue("street_address")
+		zipCode, _    = strconv.ParseInt(r.FormValue("zip_code"), 10, 32)
+		city          = r.FormValue("city")
+		state         = r.FormValue("state")
+		country       = r.FormValue("country")
+		ccNumber      = r.FormValue("credit_card_number")
+		ccMonth, _    = strconv.ParseInt(r.FormValue("credit_card_expiration_month"), 10, 32)
+		ccYear, _     = strconv.ParseInt(r.FormValue("credit_card_expiration_year"), 10, 32)
+		ccCVV, _      = strconv.ParseInt(r.FormValue("credit_card_cvv"), 10, 32)
+	)
+
+	order, err := pb.NewCheckoutServiceClient(fe.checkoutSvcConn).
+		PlaceOrder(r.Context(), &pb.PlaceOrderRequest{
+			Email: email,
+			CreditCard: &pb.CreditCardInfo{
+				CreditCardNumber:          ccNumber,
+				CreditCardExpirationMonth: int32(ccMonth),
+				CreditCardExpirationYear:  int32(ccYear),
+				CreditCardCvv:             int32(ccCVV)},
+			UserId:       sessionID(r),
+			UserCurrency: currentCurrency(r),
+			Address: &pb.Address{
+				StreetAddress: streetAddress,
+				City:          city,
+				State:         state,
+				ZipCode:       int32(zipCode),
+				Country:       country},
+		})
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "failed to complete the order"), http.StatusInternalServerError)
+		return
+	}
+	log.WithField("order", order.GetOrder().GetOrderId()).Info("order placed")
+
+	order.GetOrder().GetItems()
+	recommendations, _ := fe.getRecommendations(r.Context(), sessionID(r), nil)
+
+	totalPaid := *order.GetOrder().GetShippingCost()
+	for _, v := range order.GetOrder().GetItems() {
+		multPrice := money.MultiplySlow(*v.GetCost(), uint32(v.GetItem().GetQuantity()))
+		totalPaid = money.Must(money.Sum(totalPaid, multPrice))
+	}
+
+	currencies, err := fe.getCurrencies(r.Context())
+	if err != nil {
+		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve currencies"), http.StatusInternalServerError)
+		return
+	}
+
+	if err := templates.ExecuteTemplate(w, "order", map[string]interface{}{
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"user_currency":     currentCurrency(r),
+		"show_currency":     false,
+		"currencies":        currencies,
+		"order":             order.GetOrder(),
+		"total_paid":        &totalPaid,
+		"shipping_cost":     order.GetOrder().GetShippingCost(),
+		"recommendations":   recommendations,
+		"platform_css":      plat.css,
+		"platform_name":     plat.provider,
+		"is_cymbal_brand":   isCymbalBrand,
+		"deploymentDetails": deploymentDetailsMap,
+	}); err != nil {
+		log.Println(err)
+	}
+}
+
+func (fe *frontendServer) logoutHandler(w http.ResponseWriter, r *http.Request) {
+	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
+	log.Debug("logging out")
+	for _, c := range r.Cookies() {
+		c.Expires = time.Now().Add(-time.Hour * 24 * 365)
+		c.MaxAge = -1
+		http.SetCookie(w, c)
+	}
+	w.Header().Set("Location", "/")
+	w.WriteHeader(http.StatusFound)
+}
+
+func (fe *frontendServer) setCurrencyHandler(w http.ResponseWriter, r *http.Request) {
+	log := r.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
+	cur := r.FormValue("currency_code")
+	log.WithField("curr.new", cur).WithField("curr.old", currentCurrency(r)).
+		Debug("setting currency")
+
+	if cur != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:   cookieCurrency,
+			Value:  cur,
+			MaxAge: cookieMaxAge,
+		})
+	}
+	referer := r.Header.Get("referer")
+	if referer == "" {
+		referer = "/"
+	}
+	w.Header().Set("Location", referer)
+	w.WriteHeader(http.StatusFound)
+}
+
+// chooseAd queries for advertisements available and randomly chooses one, if
+// available. It ignores the error retrieving the ad since it is not critical.
+func (fe *frontendServer) chooseAd(ctx context.Context, ctxKeys []string, log logrus.FieldLogger) *pb.Ad {
+	ads, err := fe.getAd(ctx, ctxKeys)
+	if err != nil {
+		log.WithField("error", err).Warn("failed to retrieve ads")
+		return nil
+	}
+	return ads[rand.Intn(len(ads))]
+}
+
+func renderHTTPError(log logrus.FieldLogger, r *http.Request, w http.ResponseWriter, err error, code int) {
+	log.WithField("error", err).Error("request error")
+	errMsg := fmt.Sprintf("%+v", err)
+
+	w.WriteHeader(code)
+
+	if templateErr := templates.ExecuteTemplate(w, "error", map[string]interface{}{
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"error":             errMsg,
+		"status_code":       code,
+		"status":            http.StatusText(code),
+		"is_cymbal_brand":   isCymbalBrand,
+		"deploymentDetails": deploymentDetailsMap,
+	}); templateErr != nil {
+		log.Println(templateErr)
+	}
+}
+
+func currentCurrency(r *http.Request) string {
+	c, _ := r.Cookie(cookieCurrency)
+	if c != nil {
+		return c.Value
+	}
+	return defaultCurrency
+}
+
+func sessionID(r *http.Request) string {
+	v := r.Context().Value(ctxKeySessionID{})
+	if v != nil {
+		return v.(string)
+	}
+	return ""
+}
+
+func cartIDs(c []*pb.CartItem) []string {
+	out := make([]string, len(c))
+	for i, v := range c {
+		out[i] = v.GetProductId()
+	}
+	return out
+}
+
+// get total # of items in cart
+func cartSize(c []*pb.CartItem) int {
+	cartSize := 0
+	for _, item := range c {
+		cartSize += int(item.GetQuantity())
+	}
+	return cartSize
+}
+
+func renderMoney(money pb.Money) string {
+	currencyLogo := renderCurrencyLogo(money.GetCurrencyCode())
+	return fmt.Sprintf("%s%d.%02d", currencyLogo, money.GetUnits(), money.GetNanos()/10000000)
+}
+
+func renderCurrencyLogo(currencyCode string) string {
+	logos := map[string]string{
+		"USD": "$",
+		"CAD": "$",
+		"JPY": "¥",
+		"EUR": "€",
+		"TRY": "₺",
+		"GBP": "£",
+	}
+
+	logo := "$" //default
+	if val, ok := logos[currencyCode]; ok {
+		logo = val
+	}
+	return logo
+}
+
+func stringinSlice(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}

--- a/src/frontend/templates/cart.html
+++ b/src/frontend/templates/cart.html
@@ -1,0 +1,239 @@
+<!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{{ define "cart" }}
+    {{ template "header" . }}
+    
+    <div {{ with $.platform_css }} class="{{.}}" {{ end }}>
+        <span class="platform-flag">
+            {{$.platform_name}}
+        </span>
+    </div>
+    
+    <main role="main" class="cart-sections">
+
+        {{ if eq (len $.items) 0 }}
+        <section class="empty-cart-section">
+            <h3>Your shopping cart is empty!</h3>
+            <p>Items you add to your shopping cart will appear here.</p>
+            <a class="cymbal-button-primary" href="/" role="button">Continue Shopping</a>
+        </section>
+        {{ else }}
+        <section class="container">
+            <div class="row">
+
+                <div class="col-lg-6 col-xl-5 offset-xl-1 cart-summary-section">
+
+                    <div class="row mb-3 py-2">
+                        <div class="col-4 pl-md-0">
+                            <h3>Cart ({{ $.cart_size }})</h3>
+                        </div>
+                        <div class="col-8 pr-md-0 text-right">
+                            <form method="POST" action="/cart/empty">
+                                <button class="cymbal-button-secondary cart-summary-empty-cart-button" type="submit">
+                                    Empty Cart
+                                </button>
+                                <a class="cymbal-button-primary" href="/" role="button">
+                                    Continue Shopping
+                                </a>
+                            </form>
+                        </div>
+                    </div>
+
+                    {{ range $.items }}
+                    <div class="row cart-summary-item-row">
+                        <div class="col-md-4 pl-md-0">
+                            <a href="/product/{{.Item.Id}}">
+                                <img class="img-fluid" alt="" src="{{.Item.Picture}}" />
+                            </a>
+                        </div>
+                        <div class="col-md-8 pr-md-0">
+                            <div class="row">
+                                <div class="col">
+                                    <h4>{{ .Item.Name }}</h4>
+                                </div>
+                            </div>
+                            <div class="row cart-summary-item-row-item-id-row">
+                                <div class="col">
+                                    SKU #{{ .Item.Id }}
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col">
+                                    Quantity: {{ .Quantity }}
+                                </div>
+                                <div class="col pr-md-0 text-right">
+                                    <strong>
+                                        {{ renderMoney .Price }}
+                                    </strong>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {{ end }}
+
+                    <div class="row cart-summary-shipping-row">
+                        <div class="col pl-md-0">Shipping</div>
+                        <div class="col pr-md-0 text-right">
+                            {{- if and (eq .shipping_cost.Units 0) (eq .shipping_cost.Nanos 0) -}}
+                            FREE
+                            {{- else -}}
+                            {{ renderMoney .shipping_cost }}
+                            {{- end -}}
+                        </div>
+                    </div>
+
+                    <div class="row cart-summary-total-row">
+                        <div class="col pl-md-0">Total</div>
+                        <div class="col pr-md-0 text-right">{{ renderMoney .total_cost }}</div>
+                    </div>
+
+                </div>
+
+                <div class="col-lg-5 offset-lg-1 col-xl-4">
+
+                    <form class="cart-checkout-form" action="/cart/checkout" method="POST">
+
+                        <div class="row">
+                            <div class="col">
+                                <h3>Shipping Address</h3>
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            <div class="col cymbal-form-field">
+                                <label for="email">E-mail Address</label>
+                                <input type="email" id="email"
+                                    name="email" value="someone@example.com" required>
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            <div class="col cymbal-form-field">
+                                <label for="street_address">Street Address</label>
+                                <input type="text" name="street_address"
+                                    id="street_address" value="1600 Amphitheatre Parkway" required>
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            <div class="col cymbal-form-field">
+                                <label for="zip_code">Zip Code</label>
+                                <input type="text"
+                                    name="zip_code" id="zip_code" value="94043" required pattern="\d{4,5}">
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            <div class="col cymbal-form-field">
+                                <label for="city">City</label>
+                                <input type="text" name="city" id="city"
+                                    value="Mountain View" required>
+                                </div>
+                            </div>
+
+                        <div class="form-row">
+                            <div class="col-md-5 cymbal-form-field">
+                                <label for="state">State</label>
+                                <input type="text" name="state" id="state"
+                                    value="CA" required>
+                            </div>
+                            <div class="col-md-7 cymbal-form-field">
+                                <label for="country">Country</label>
+                                <input type="text" id="country"
+                                    placeholder="Country Name"
+                                    name="country" value="United States" required>
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col">
+                                <h3 class="payment-method-heading">Payment Method</h3>
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            <div class="col cymbal-form-field">
+                                <label for="credit_card_number">Credit Card Number</label>
+                                <input type="text" id="credit_card_number"
+                                    name="credit_card_number"
+                                    placeholder="0000-0000-0000-0000"
+                                    value="4432-8015-6152-0454"
+                                    required pattern="\d{4}-\d{4}-\d{4}-\d{4}">
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            <div class="col-md-5 cymbal-form-field">
+                                <label for="credit_card_expiration_month">Month</label>
+                                <select name="credit_card_expiration_month" id="credit_card_expiration_month">
+                                    <option value="1">January</option>
+                                    <option value="2">February</option>
+                                    <option value="3">March</option>
+                                    <option value="4">April</option>
+                                    <option value="5">May</option>
+                                    <option value="6">June</option>
+                                    <option value="7">July</option>
+                                    <option value="8">August</option>
+                                    <option value="9">September</option>
+                                    <option value="10">October</option>
+                                    <option value="11">November</option>
+                                    <option value="12">January</option>
+                                </select>
+                                <img src="/static/icons/Hipster_DownArrow.svg" alt="" class="cymbal-dropdown-chevron">
+                            </div>
+                            <div class="col-md-4 cymbal-form-field">
+                                    <label for="credit_card_expiration_year">Year</label>
+                                    <select name="credit_card_expiration_year" id="credit_card_expiration_year">
+                                    {{ range $i, $y := $.expiration_years}}<option value="{{$y}}"
+                                        {{if eq $i 1 -}}
+                                            selected="selected"
+                                        {{- end}}
+                                    >{{$y}}</option>{{end}}
+                                    </select>
+                                    <img src="/static/icons/Hipster_DownArrow.svg" alt="" class="cymbal-dropdown-chevron">
+                                </div>
+                            <div class="col-md-3 cymbal-form-field">
+                                <label for="credit_card_cvv">CVV</label>
+                                <input type="password" id="credit_card_cvv"
+                                    name="credit_card_cvv" value="672" required pattern="\d{3}">
+                            </div>
+                        </div>
+
+                        <div class="form-row justify-content-center">
+                            <div class="col text-center">
+                                <button class="cymbal-button-primary" type="submit">
+                                    Place Order
+                                </button>
+                            </div>
+                        </div>
+
+                    </form>
+
+                </div>
+
+            </div>
+        </section>
+        {{ end }} <!-- end if $.items -->
+
+    </main>
+
+    {{ if $.recommendations }}
+        {{ template "recommendations" $.recommendations }}
+    {{ end }}
+
+    {{ template "footer" . }}
+    {{ end }}

--- a/src/frontend/templates/order.html
+++ b/src/frontend/templates/order.html
@@ -1,0 +1,92 @@
+<!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{{ define "order" }}
+
+    {{ template "header" . }}
+
+    <div {{ with $.platform_css }} class="{{.}}" {{ end }}>
+        <span class="platform-flag">
+            {{$.platform_name}}
+        </span>
+    </div>
+
+    <main role="main" class="order">
+
+        <section class="container order-complete-section">
+            <div class="row">
+                <div class="col-12 text-center">
+                    <h3>
+                        Your order is complete!
+                    </h3>
+                </div>
+                <div class="col-12 text-center">
+                    <p>We've sent you a confirmation email.</p>
+                </div>
+            </div>
+            <div class="row border-bottom-solid padding-y-24">
+                <div class="col-6 pl-md-0">
+                    Confirmation #
+                </div>
+                <div class="col-6 pr-md-0 text-right">
+                    {{.order.OrderId}}
+                </div>
+            </div>
+            <div class="row border-bottom-solid padding-y-24">
+                <div class="col-6 pl-md-0">
+                    Tracking #
+                </div>
+                <div class="col-6 pr-md-0 text-right">
+                    {{.order.ShippingTrackingId}}
+                </div>
+            </div>
+            <div class="row border-bottom-solid padding-y-24">
+                <div class="col-6 pl-md-0">
+                    Shipping
+                </div>
+                <div class="col-6 pr-md-0 text-right">
+                    {{- if and (eq .shipping_cost.Units 0) (eq .shipping_cost.Nanos 0) -}}
+                    FREE
+                    {{- else -}}
+                    {{renderMoney .shipping_cost}}
+                    {{- end -}}
+                </div>
+            </div>
+            <div class="row padding-y-24">
+                <div class="col-6 pl-md-0">
+                    Total Paid
+                </div>
+                <div class="col-6 pr-md-0 text-right">
+                    {{renderMoney .total_paid}}
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-12 text-center">
+                    <a class="cymbal-button-primary" href="/" role="button">
+                        Continue Shopping
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        {{ if $.recommendations }}
+            {{ template "recommendations" $.recommendations }}
+        {{ end }}
+
+    </main>
+
+    {{ template "footer" . }}
+    {{ end }}

--- a/tests/free_shipping_test.py
+++ b/tests/free_shipping_test.py
@@ -1,0 +1,149 @@
+"""
+Playwright tests for free shipping feature.
+
+Verifies that:
+- Orders with item subtotal >= $50 USD receive free shipping on both the cart page
+  and the order confirmation page.
+- Orders with item subtotal < $50 USD are charged normal shipping on both pages.
+"""
+
+import os
+import pytest
+from playwright.sync_api import Page, expect
+
+SHOP_URL = os.environ.get(
+    "SHOP_URL",
+    "https://shop--ai-f3a9b2c1d4e50678-demo.crafting.site.sandboxes.run",
+)
+
+# Products from the catalog:
+#   Watch  ($109.99) — one unit is well above the $50 threshold
+#   Mug    ($8.99)   — one unit is below the $50 threshold
+PRODUCT_ABOVE_THRESHOLD = {"id": "1YMWWN1N4O", "name": "Watch", "qty": "1"}
+PRODUCT_BELOW_THRESHOLD = {"id": "6E92ZMYYFZ", "name": "Mug", "qty": "1"}
+
+CHECKOUT_FIELDS = {
+    "email": "test@example.com",
+    "street_address": "1600 Amphitheatre Parkway",
+    "zip_code": "94043",
+    "city": "Mountain View",
+    "state": "CA",
+    "country": "United States",
+    "credit_card_number": "4432-8015-6152-0454",
+    "credit_card_cvv": "672",
+}
+
+
+def add_product_to_cart(page: Page, product_id: str, qty: str = "1") -> None:
+    """Navigate to a product page and add it to the cart."""
+    page.goto(f"{SHOP_URL}/product/{product_id}")
+    page.select_option("select[name='quantity']", qty)
+    page.click("button[type='submit']")
+    # After adding, we are redirected to /cart
+    page.wait_for_url(f"{SHOP_URL}/cart")
+
+
+def empty_cart(page: Page) -> None:
+    """Empty the shopping cart if it has items."""
+    page.goto(f"{SHOP_URL}/cart")
+    empty_btn = page.locator("button.cart-summary-empty-cart-button")
+    if empty_btn.is_visible():
+        empty_btn.click()
+        page.wait_for_url(f"{SHOP_URL}/")
+
+
+def fill_and_place_order(page: Page) -> None:
+    """Fill in the checkout form and submit the order from the cart page."""
+    page.fill("input[name='email']", CHECKOUT_FIELDS["email"])
+    page.fill("input[name='street_address']", CHECKOUT_FIELDS["street_address"])
+    page.fill("input[name='zip_code']", CHECKOUT_FIELDS["zip_code"])
+    page.fill("input[name='city']", CHECKOUT_FIELDS["city"])
+    page.fill("input[name='state']", CHECKOUT_FIELDS["state"])
+    page.fill("input[name='country']", CHECKOUT_FIELDS["country"])
+    page.fill("input[name='credit_card_number']", CHECKOUT_FIELDS["credit_card_number"])
+    page.fill("input[name='credit_card_cvv']", CHECKOUT_FIELDS["credit_card_cvv"])
+    # Submit the checkout form (not the "Empty Cart" button) and wait for confirmation
+    page.click(".cart-checkout-form button[type='submit']")
+    # Wait for the order confirmation heading (up to 60s for gRPC call chain)
+    page.wait_for_selector("text=Your order is complete!", timeout=60000)
+
+
+def get_cart_shipping_text(page: Page) -> str:
+    """Return the text content of the shipping row in the cart."""
+    shipping_row = page.locator(".cart-summary-shipping-row")
+    return shipping_row.inner_text()
+
+
+def get_order_shipping_text(page: Page) -> str:
+    """Return the text content of the Shipping row on the order confirmation page."""
+    # Find all rows in the order section and locate the one labelled "Shipping"
+    rows = page.locator(".order-complete-section .row")
+    for i in range(rows.count()):
+        row_text = rows.nth(i).inner_text()
+        if "Shipping" in row_text:
+            return row_text
+    return ""
+
+
+def test_free_shipping_above_threshold(page: Page) -> None:
+    """
+    An order whose item subtotal is >= $50 USD must show FREE shipping
+    on both the cart page and the order confirmation page.
+    The Watch costs $109.99 — well above the $50 threshold.
+    """
+    empty_cart(page)
+    add_product_to_cart(page, PRODUCT_ABOVE_THRESHOLD["id"], PRODUCT_ABOVE_THRESHOLD["qty"])
+
+    # --- Cart page assertions ---
+    page.goto(f"{SHOP_URL}/cart")
+    cart_shipping = get_cart_shipping_text(page)
+    assert "FREE" in cart_shipping, (
+        f"Cart page should show FREE shipping for order >= $50, got: {cart_shipping!r}"
+    )
+
+    # Confirm the total doesn't include a shipping charge
+    total_row = page.locator(".cart-summary-total-row").inner_text()
+    # Total should equal the item price alone (no shipping added on top)
+    assert "$" in total_row, (
+        f"Total row should show a dollar amount, got: {total_row!r}"
+    )
+
+    # --- Place the order and check confirmation page ---
+    fill_and_place_order(page)
+
+    order_shipping = get_order_shipping_text(page)
+    assert "FREE" in order_shipping, (
+        f"Order confirmation should show FREE shipping for order >= $50, got: {order_shipping!r}"
+    )
+
+
+def test_paid_shipping_below_threshold(page: Page) -> None:
+    """
+    An order whose item subtotal is < $50 USD must show a non-zero shipping
+    cost on both the cart page and the order confirmation page.
+    The Mug costs $8.99 — well below the $50 threshold.
+    """
+    empty_cart(page)
+    add_product_to_cart(page, PRODUCT_BELOW_THRESHOLD["id"], PRODUCT_BELOW_THRESHOLD["qty"])
+
+    # --- Cart page assertions ---
+    page.goto(f"{SHOP_URL}/cart")
+    cart_shipping = get_cart_shipping_text(page)
+    assert "FREE" not in cart_shipping, (
+        f"Cart page should NOT show FREE shipping for order < $50, got: {cart_shipping!r}"
+    )
+    # Shipping should show a dollar amount
+    assert "$" in cart_shipping, (
+        f"Cart page should show a dollar shipping cost for order < $50, got: {cart_shipping!r}"
+    )
+
+    # --- Place the order and check confirmation page ---
+    fill_and_place_order(page)
+
+    order_shipping = get_order_shipping_text(page)
+    assert "FREE" not in order_shipping, (
+        f"Order confirmation should NOT show FREE shipping for order < $50, got: {order_shipping!r}"
+    )
+    assert "$" in order_shipping, (
+        f"Order confirmation should show a dollar shipping cost for order < $50, got: {order_shipping!r}"
+    )


### PR DESCRIPTION
## Summary

Implements free shipping for orders with an item subtotal of $50 or more (USD), as requested in [crafting-demo/boutique#2](https://github.com/crafting-demo/boutique/issues/2).

Closes #2

---

## Changes

### `src/checkoutservice/main.go`
- Added `freeShippingThresholdUSD = 50` constant
- Added `itemSubtotalUSD()` helper that fetches USD product prices and sums them across cart items
- In `prepareOrderItemsAndShippingQuoteFromCart()`: when the USD subtotal meets or exceeds the threshold, the shipping cost is zeroed out before currency conversion

### `src/frontend/handlers.go`
- Added matching `freeShippingThresholdUSD = 50` constant
- In `viewCartHandler()`: accumulate a USD subtotal while iterating cart items; override `shippingCost` to `$0` for the cart-page preview when the threshold is met
- In `placeOrderHandler()`: pass `shipping_cost` (from the order result) to the `order` template

### `src/frontend/templates/cart.html`
- Shipping row now renders `FREE` when the shipping cost is zero, otherwise renders the monetary amount

### `src/frontend/templates/order.html`
- Added a new **Shipping** row (with `FREE` or the amount) between the tracking number and the Total Paid rows

### `tests/free_shipping_test.py`
- Playwright end-to-end tests covering:
  - **Watch ($109.99)**: cart shows `FREE`, order confirmation shows `FREE`
  - **Mug ($8.99)**: cart shows a dollar amount, order confirmation shows a dollar amount

---

## Test Results

Both Playwright tests pass in sandbox **ai-e7f3b2a9c14d8e05** (template **boutique-fe**):

```
tests/free_shipping_test.py::test_free_shipping_above_threshold[chromium] PASSED
tests/free_shipping_test.py::test_paid_shipping_below_threshold[chromium]  PASSED

2 passed in 1.88s
```

Services were started/stopped via `cs up checkoutservice` / `cs up frontend` in their respective workspaces after each code change.

---

**Sandbox:** ai-e7f3b2a9c14d8e05  
**Template:** boutique-fe