### PR TITLE
feat: free shipping on orders over $50

### DIFF
--- a/e2e-tests/free-shipping.spec.js
+++ b/e2e-tests/free-shipping.spec.js
@@ -1,0 +1,100 @@
+const { test, expect } = require('@playwright/test');
+
+// Watch costs $109.99 — well over $50 threshold
+const EXPENSIVE_PRODUCT_ID = '1YMWWN1N4O';
+// Bamboo Glass Jar costs $5.49 — under $50 threshold
+const CHEAP_PRODUCT_ID = '9SIQT8TOJO';
+
+test.describe('Free shipping on orders over $50', () => {
+
+  test.beforeEach(async ({ page }) => {
+    // Empty the cart before each test by visiting cart and clicking empty if available
+    await page.goto('/cart');
+    const emptyBtn = page.locator('button:has-text("Empty Cart")');
+    if (await emptyBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await emptyBtn.click();
+      await page.waitForURL('**/');
+    }
+  });
+
+  test('order over $50 gets free shipping on cart page and confirmation page', async ({ page }) => {
+    // Add Watch ($109.99) to cart — this is over $50
+    await page.goto(`/product/${EXPENSIVE_PRODUCT_ID}`);
+    await page.locator('button:has-text("Add to Cart")').click();
+    await page.waitForURL('**/cart');
+
+    // ASSERT: Cart page shows "FREE" shipping
+    const cartShippingRow = page.locator('.cart-summary-shipping-row');
+    await expect(cartShippingRow).toBeVisible();
+    const cartShippingValue = cartShippingRow.locator('.text-right');
+    await expect(cartShippingValue).toHaveText('FREE');
+
+    // ASSERT: Cart total should NOT include shipping (total = item subtotal)
+    const cartTotalRow = page.locator('.cart-summary-total-row');
+    const cartTotalValue = cartTotalRow.locator('.text-right');
+    await expect(cartTotalValue).toHaveText('$109.99');
+
+    // Place the order using the pre-filled form values
+    await page.locator('button:has-text("Place Order")').click();
+    await page.waitForURL('**/cart/checkout');
+
+    // ASSERT: Order confirmation page exists
+    await expect(page.locator('text=Your order is complete!')).toBeVisible();
+
+    // ASSERT: Order confirmation page shows "FREE" shipping
+    const shippingRow = page.locator('.border-bottom-solid.padding-y-24').filter({ hasText: 'Shipping' });
+    await expect(shippingRow).toBeVisible();
+    const shippingValue = shippingRow.locator('.text-right');
+    await expect(shippingValue).toHaveText('FREE');
+
+    // ASSERT: Total paid equals the item cost (no shipping)
+    const totalRow = page.locator('.padding-y-24').filter({ hasText: 'Total Paid' });
+    await expect(totalRow).toBeVisible();
+    const totalValue = totalRow.locator('.text-right');
+    await expect(totalValue).toHaveText('$109.99');
+  });
+
+  test('order under $50 gets normal shipping on cart page and confirmation page', async ({ page }) => {
+    // Add Bamboo Glass Jar ($5.49) to cart — this is under $50
+    await page.goto(`/product/${CHEAP_PRODUCT_ID}`);
+    await page.locator('button:has-text("Add to Cart")').click();
+    await page.waitForURL('**/cart');
+
+    // ASSERT: Cart page shows a dollar amount for shipping (NOT "FREE")
+    const cartShippingRow = page.locator('.cart-summary-shipping-row');
+    await expect(cartShippingRow).toBeVisible();
+    const cartShippingValue = cartShippingRow.locator('.text-right');
+    const cartShippingText = await cartShippingValue.textContent();
+    expect(cartShippingText.trim()).not.toBe('FREE');
+    expect(cartShippingText.trim()).toMatch(/^\$/);
+
+    // ASSERT: Total includes shipping (should be more than $5.49)
+    const cartTotalRow = page.locator('.cart-summary-total-row');
+    const cartTotalText = await cartTotalRow.locator('.text-right').textContent();
+    const totalVal = parseFloat(cartTotalText.trim().replace('$', ''));
+    expect(totalVal).toBeGreaterThan(5.49);
+
+    // Place the order
+    await page.locator('button:has-text("Place Order")').click();
+    await page.waitForURL('**/cart/checkout');
+
+    // ASSERT: Order confirmation page exists
+    await expect(page.locator('text=Your order is complete!')).toBeVisible();
+
+    // ASSERT: Order confirmation page shows a shipping cost (NOT "FREE")
+    const shippingRow = page.locator('.border-bottom-solid.padding-y-24').filter({ hasText: 'Shipping' });
+    await expect(shippingRow).toBeVisible();
+    const shippingValue = shippingRow.locator('.text-right');
+    const orderShippingText = await shippingValue.textContent();
+    expect(orderShippingText.trim()).not.toBe('FREE');
+    expect(orderShippingText.trim()).toMatch(/^\$/);
+
+    // ASSERT: Total paid includes shipping
+    const totalRow = page.locator('.padding-y-24').filter({ hasText: 'Total Paid' });
+    await expect(totalRow).toBeVisible();
+    const totalPaidText = await totalRow.locator('.text-right').textContent();
+    const orderTotal = parseFloat(totalPaidText.trim().replace('$', ''));
+    expect(orderTotal).toBeGreaterThan(5.49);
+  });
+
+});

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "e2e-tests",
+  "version": "1.0.0",
+  "description": "End-to-end tests for Online Boutique",
+  "scripts": {
+    "test": "npx playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0"
+  }
+}

--- a/e2e-tests/playwright.config.js
+++ b/e2e-tests/playwright.config.js
@@ -1,0 +1,12 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: '.',
+  timeout: 60000,
+  retries: 1,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://frontend:8080',
+    headless: true,
+    ignoreHTTPSErrors: true,
+  },
+});

--- a/services/src/checkoutservice/main.go
+++ b/services/src/checkoutservice/main.go
@@ -296,6 +296,23 @@ func (cs *checkoutService) prepareOrderItemsAndShippingQuoteFromCart(ctx context
 	if err != nil {
 		return out, fmt.Errorf("shipping quote failure: %+v", err)
 	}
+
+	// Free shipping for orders with item subtotal >= $50 USD
+	subtotalUSD := pb.Money{CurrencyCode: usdCurrency, Units: 0, Nanos: 0}
+	for _, item := range orderItems {
+		itemCostUSD, err := cs.convertCurrency(ctx, item.Cost, usdCurrency)
+		if err != nil {
+			return out, fmt.Errorf("failed to convert item cost to USD: %+v", err)
+		}
+		multPrice := money.MultiplySlow(*itemCostUSD, uint32(item.GetItem().GetQuantity()))
+		subtotalUSD = money.Must(money.Sum(subtotalUSD, multPrice))
+	}
+	const freeShippingThresholdUnits int64 = 50
+	if subtotalUSD.GetUnits() >= freeShippingThresholdUnits {
+		log.Infof("order subtotal $%d.%02d meets free shipping threshold ($%d)", subtotalUSD.GetUnits(), subtotalUSD.GetNanos()/10000000, freeShippingThresholdUnits)
+		shippingUSD = &pb.Money{CurrencyCode: usdCurrency, Units: 0, Nanos: 0}
+	}
+
 	shippingPrice, err := cs.convertCurrency(ctx, shippingUSD, userCurrency)
 	if err != nil {
 		return out, fmt.Errorf("failed to convert shipping cost to currency: %+v", err)

--- a/services/src/frontend/handlers.go
+++ b/services/src/frontend/handlers.go
@@ -275,6 +275,7 @@ func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request
 	}
 	items := make([]cartItemView, len(cart))
 	totalPrice := pb.Money{CurrencyCode: currentCurrency(r)}
+	totalPriceUSD := pb.Money{CurrencyCode: "USD"}
 	for i, item := range cart {
 		p, err := fe.getProduct(r.Context(), item.GetProductId())
 		if err != nil {
@@ -293,7 +294,18 @@ func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request
 			Quantity: item.GetQuantity(),
 			Price:    &multPrice}
 		totalPrice = money.Must(money.Sum(totalPrice, multPrice))
+
+		// Compute USD subtotal for free shipping threshold check
+		priceUSD := money.MultiplySlow(*p.GetPriceUsd(), uint32(item.GetQuantity()))
+		totalPriceUSD = money.Must(money.Sum(totalPriceUSD, priceUSD))
 	}
+
+	// Free shipping when item subtotal >= $50 USD
+	freeShipping := totalPriceUSD.GetUnits() >= 50
+	if freeShipping {
+		shippingCost = &pb.Money{CurrencyCode: currentCurrency(r), Units: 0, Nanos: 0}
+	}
+
 	totalPrice = money.Must(money.Sum(totalPrice, *shippingCost))
 	year := time.Now().Year()
 
@@ -305,6 +317,7 @@ func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request
 		"recommendations":   recommendations,
 		"cart_size":         cartSize(cart),
 		"shipping_cost":     shippingCost,
+		"free_shipping":     freeShipping,
 		"show_currency":     true,
 		"total_cost":        totalPrice,
 		"items":             items,
@@ -367,6 +380,10 @@ func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Reque
 		totalPaid = money.Must(money.Sum(totalPaid, multPrice))
 	}
 
+	// Determine if free shipping was applied (shipping cost is zero)
+	sc := order.GetOrder().GetShippingCost()
+	freeShipping := sc.GetUnits() == 0 && sc.GetNanos() == 0
+
 	currencies, err := fe.getCurrencies(r.Context())
 	if err != nil {
 		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve currencies"), http.StatusInternalServerError)
@@ -381,6 +398,7 @@ func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Reque
 		"currencies":        currencies,
 		"order":             order.GetOrder(),
 		"total_paid":        &totalPaid,
+		"free_shipping":     freeShipping,
 		"recommendations":   recommendations,
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
@@ -496,10 +514,10 @@ func renderCurrencyLogo(currencyCode string) string {
 	logos := map[string]string{
 		"USD": "$",
 		"CAD": "$",
-		"JPY": "¥",
-		"EUR": "€",
-		"TRY": "₺",
-		"GBP": "£",
+		"JPY": "\u00a5",
+		"EUR": "\u20ac",
+		"TRY": "\u20ba",
+		"GBP": "\u00a3",
 	}
 
 	logo := "$" //default

--- a/services/src/frontend/templates/cart.html
+++ b/services/src/frontend/templates/cart.html
@@ -87,7 +87,7 @@
 
                     <div class="row cart-summary-shipping-row">
                         <div class="col pl-md-0">Shipping</div>
-                        <div class="col pr-md-0 text-right">{{ renderMoney .shipping_cost }}</div>
+                        <div class="col pr-md-0 text-right">{{ if $.free_shipping }}FREE{{ else }}{{ renderMoney .shipping_cost }}{{ end }}</div>
                     </div>
 
                     <div class="row cart-summary-total-row">

--- a/services/src/frontend/templates/order.html
+++ b/services/src/frontend/templates/order.html
@@ -53,6 +53,14 @@
                     {{.order.ShippingTrackingId}}
                 </div>
             </div>
+            <div class="row border-bottom-solid padding-y-24">
+                <div class="col-6 pl-md-0">
+                    Shipping
+                </div>
+                <div class="col-6 pr-md-0 text-right">
+                    {{ if $.free_shipping }}FREE{{ else }}{{renderMoney .order.ShippingCost}}{{ end }}
+                </div>
+            </div>
             <div class="row padding-y-24">
                 <div class="col-6 pl-md-0">
                     Total Paid


### PR DESCRIPTION
## Summary

Implements free shipping for orders with an item subtotal of $50 or more (USD). This change spans both the `checkoutservice` and `frontend` services.

Fixes [crafting-demo/boutique#6](https://github.com/crafting-demo/boutique/issues/6)

## Changes

### checkoutservice (`services/src/checkoutservice/main.go`)
- In `prepareOrderItemsAndShippingQuoteFromCart`, after getting the shipping quote, compute the item subtotal in USD
- If the subtotal >= $50, set the shipping cost to $0 before currency conversion
- This ensures the PlaceOrder RPC returns zero shipping for qualifying orders

### frontend (`services/src/frontend/handlers.go`)
- In `viewCartHandler`, compute the USD subtotal alongside the display-currency subtotal
- If subtotal >= $50 USD, zero out the shipping cost and set `free_shipping = true`
- In `placeOrderHandler`, detect free shipping by checking if the returned shipping cost is zero
- Pass `free_shipping` flag to both cart and order templates

### Templates
- **cart.html**: Show "FREE" instead of the dollar amount when `free_shipping` is true
- **order.html**: Add a "Shipping" row showing "FREE" or the shipping cost

### E2E Tests (`e2e-tests/`)
- Playwright test with two scenarios:
  1. **Over $50**: Add a Watch ($109.99), verify cart shows "FREE" shipping and total of $109.99, place order, verify confirmation page shows "FREE" shipping and total of $109.99
  2. **Under $50**: Add a Bamboo Glass Jar ($5.49), verify cart shows a dollar shipping amount, place order, verify confirmation page shows shipping cost

## Test Results

```
Running 2 tests using 1 worker

  ✓  1 order over $50 gets free shipping on cart page and confirmation page (716ms)
  ✓  2 order under $50 gets normal shipping on cart page and confirmation page (632ms)

  2 passed (2.2s)
```

Both tests verify shipping display on **both the cart page and the order confirmation page**.

## Sandbox & Template

- **Sandbox**: `ai-d7f3a9b2c1e84f60`
- **Template**: `boutique-fe`

Services were started/stopped via `cs up`/`cs down`/`cs restart` daemons (`checkoutservice` on checkout workspace, `frontend` on frontend workspace).